### PR TITLE
Make methods compatible with \DateTimeInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/config":               "^4.4|^5.0",
         "symfony/yaml":                 "^4.4|^5.0",
-        "twig/twig":                    "^1.23|^2.0"
+        "twig/twig":                    "^1.23|^2.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
 
     "autoload": {

--- a/src/Bridge/Doctrine/ORM/EventRepository.php
+++ b/src/Bridge/Doctrine/ORM/EventRepository.php
@@ -20,13 +20,13 @@ namespace CalendR\Bridge\Doctrine\ORM;
 trait EventRepository
 {
     /**
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param array     $options
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param array              $options
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getEventsQueryBuilder(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEventsQueryBuilder(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         $begin = sprintf("'%s'", $begin->format('Y-m-d H:i:s'));
         $end   = sprintf("'%s'", $end->format('Y-m-d H:i:s'));
@@ -61,25 +61,25 @@ trait EventRepository
     }
 
     /**
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param array     $options
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param array              $options
      *
      * @return \Doctrine\ORM\Query
      */
-    public function getEventsQuery(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEventsQuery(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         return $this->getEventsQueryBuilder($begin, $end, $options)->getQuery();
     }
 
     /**
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param array     $options
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param array              $options
      *
      * @return array<\CalendR\Event\EventInterface>
      */
-    public function getEvents(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEvents(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         return $this->getEventsQuery($begin, $end, $options)->getResult();
     }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -60,7 +60,7 @@ class Calendar
      */
     public function getYear($yearOrStart)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-01-01', $yearOrStart));
         }
 
@@ -68,14 +68,14 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart year if month is filled, month begin datetime otherwise
-     * @param null|int      $month       number (1~12)
+     * @param \DateTimeInterface|int $yearOrStart year if month is filled, month begin datetime otherwise
+     * @param null|int               $month       number (1~12)
      *
      * @return PeriodInterface
      */
     public function getMonth($yearOrStart, $month = null)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-%s-01', $yearOrStart, $month));
         }
 
@@ -83,8 +83,8 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart
-     * @param null|int      $week
+     * @param \DateTimeInterface|int $yearOrStart
+     * @param null|int               $week
      *
      * @return PeriodInterface
      */
@@ -92,7 +92,7 @@ class Calendar
     {
         $factory = $this->getFactory();
 
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-W%s', $yearOrStart, str_pad($week, 2, 0, STR_PAD_LEFT)));
         }
 
@@ -100,15 +100,15 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart
-     * @param null|int      $month
-     * @param null|int      $day
+     * @param \DateTimeInterface|int $yearOrStart
+     * @param null|int               $month
+     * @param null|int               $day
      *
      * @return PeriodInterface
      */
     public function getDay($yearOrStart, $month = null, $day = null)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-%s-%s', $yearOrStart, $month, $day));
         }
 
@@ -116,15 +116,15 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart
-     * @param null|int      $month
-     * @param null|int      $day
+     * @param \DateTimeInterface|int $yearOrStart
+     * @param null|int               $month
+     * @param null|int               $day
      *
      * @return PeriodInterface
      */
     public function getHour($yearOrStart, $month = null, $day = null, $hour = null)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-%s-%s %s:00', $yearOrStart, $month, $day, $hour));
         }
 
@@ -132,15 +132,15 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart
-     * @param null|int      $month
-     * @param null|int      $day
+     * @param \DateTimeInterface|int $yearOrStart
+     * @param null|int               $month
+     * @param null|int               $day
      *
      * @return PeriodInterface
      */
     public function getMinute($yearOrStart, $month = null, $day = null, $hour = null, $minute = null)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(sprintf('%s-%s-%s %s:%s', $yearOrStart, $month, $day, $hour, $minute));
         }
 
@@ -148,15 +148,15 @@ class Calendar
     }
 
     /**
-     * @param \DateTime|int $yearOrStart
-     * @param null|int      $month
-     * @param null|int      $day
+     * @param \DateTimeInterface|int $yearOrStart
+     * @param null|int               $month
+     * @param null|int               $day
      *
      * @return PeriodInterface
      */
     public function getSecond($yearOrStart, $month = null, $day = null, $hour = null, $minute = null, $second = null)
     {
-        if (!$yearOrStart instanceof \DateTime) {
+        if (!$yearOrStart instanceof \DateTimeInterface) {
             $yearOrStart = new \DateTime(
                 sprintf('%s-%s-%s %s:%s:%s', $yearOrStart, $month, $day, $hour, $minute, $second)
             );

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -23,11 +23,11 @@ abstract class AbstractEvent implements EventInterface
     /**
      * Check if the given date is during the event.
      *
-     * @param \DateTime $datetime
+     * @param \DateTimeInterface $datetime
      *
      * @return bool true if $datetime is during the event, false otherwise
      */
-    public function contains(\DateTime $datetime)
+    public function contains(\DateTimeInterface $datetime)
     {
         return $this->getBegin() <= $datetime && $datetime < $this->getEnd();
     }

--- a/src/Event/Collection/Basic.php
+++ b/src/Event/Collection/Basic.php
@@ -96,7 +96,7 @@ class Basic implements CollectionInterface
         foreach ($this->events as $event) {
             if ($index instanceof PeriodInterface && $index->containsEvent($event)) {
                 $result[] = $event;
-            } elseif ($index instanceof \DateTime && $event->contains($index)) {
+            } elseif ($index instanceof \DateTimeInterface && $event->contains($index)) {
                 $result[] = $event;
             }
         }

--- a/src/Event/Collection/Indexed.php
+++ b/src/Event/Collection/Indexed.php
@@ -36,11 +36,11 @@ class Indexed implements CollectionInterface
 
     /**
      * The function used to index events.
-     * Takes a \DateTime in parameter and must return an array index for this value.
+     * Takes a \DateTimeInterface in parameter and must return an array index for this value.
      *
      * By default :
      * ```php
-     *  function(\DateTime $dateTime) {
+     *  function(\DateTimeInterface $dateTime) {
      *      return $dateTime->format('Y-m-d');
      *  }
      * ```
@@ -58,7 +58,7 @@ class Indexed implements CollectionInterface
         if (is_callable($callable)) {
             $this->indexFunction = $callable;
         } else {
-            $this->indexFunction = function (\DateTime $dateTime) {
+            $this->indexFunction = function (\DateTimeInterface $dateTime) {
                 return $dateTime->format('Y-m-d');
             };
         }
@@ -127,7 +127,7 @@ class Indexed implements CollectionInterface
         if ($index instanceof PeriodInterface) {
             $index = $index->getBegin();
         }
-        if ($index instanceof \DateTime) {
+        if ($index instanceof \DateTimeInterface) {
             $index = $this->computeIndex($index);
         }
 
@@ -153,7 +153,7 @@ class Indexed implements CollectionInterface
     /**
      * Computes event index.
      *
-     * @param EventInterface|\DateTime $toCompute
+     * @param EventInterface|\DateTimeInterface $toCompute
      *
      * @return string
      */

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -21,12 +21,12 @@ namespace CalendR\Event;
 class Event extends AbstractEvent
 {
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $begin;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $end;
 
@@ -35,7 +35,7 @@ class Event extends AbstractEvent
      */
     protected $uid;
 
-    public function __construct($uid, \DateTime $start, \DateTime $end)
+    public function __construct($uid, \DateTimeInterface $start, \DateTimeInterface $end)
     {
         if ($start->diff($end)->invert == 1) {
             throw new \InvalidArgumentException('Events usually start before they end');
@@ -61,7 +61,7 @@ class Event extends AbstractEvent
     /**
      * Returns the event begin.
      *
-     * @return \DateTime event begin
+     * @return \DateTimeInterface event begin
      */
     public function getBegin()
     {
@@ -71,7 +71,7 @@ class Event extends AbstractEvent
     /**
      * Returns the event end.
      *
-     * @return \DateTime event end
+     * @return \DateTimeInterface event end
      */
     public function getEnd()
     {

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -36,7 +36,7 @@ interface EventInterface
      *
      * @abstract
      *
-     * @return \DateTime event begin
+     * @return \DateTimeInterface event begin
      */
     public function getBegin();
 
@@ -45,7 +45,7 @@ interface EventInterface
      *
      * @abstract
      *
-     * @return \DateTime event end
+     * @return \DateTimeInterface event end
      */
     public function getEnd();
 
@@ -54,11 +54,11 @@ interface EventInterface
      *
      * @abstract
      *
-     * @param \DateTime $datetime
+     * @param \DateTimeInterface $datetime
      *
      * @return bool true if $datetime is during the event, false otherwise
      */
-    public function contains(\DateTime $datetime);
+    public function contains(\DateTimeInterface $datetime);
 
     /**
      * Check if the given period is during the event.

--- a/src/Event/Provider/Aggregate.php
+++ b/src/Event/Provider/Aggregate.php
@@ -56,13 +56,13 @@ class Aggregate implements ProviderInterface
      * Return events that matches to $begin && $end
      * $end date should be exclude.
      *
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param array     $options
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param array              $options
      *
      * @return \CalendR\Event\EventInterface
      */
-    public function getEvents(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEvents(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         $events = array();
 

--- a/src/Event/Provider/Basic.php
+++ b/src/Event/Provider/Basic.php
@@ -29,7 +29,7 @@ class Basic implements ProviderInterface, \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      */
-    public function getEvents(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEvents(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         $events = array();
         foreach ($this->events as $event) {

--- a/src/Event/Provider/Cache.php
+++ b/src/Event/Provider/Cache.php
@@ -57,7 +57,7 @@ class Cache implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getEvents(\DateTime $begin, \DateTime $end, array $options = array())
+    public function getEvents(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array())
     {
         $cacheKey = md5(serialize(array($begin, $end, $options)));
 

--- a/src/Event/Provider/ProviderInterface.php
+++ b/src/Event/Provider/ProviderInterface.php
@@ -22,11 +22,11 @@ interface ProviderInterface
      * Return events that matches to $begin && $end
      * $end date should be exclude.
      *
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param array     $options
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param array              $options
      *
      * @return \CalendR\Event\EventInterface[]
      */
-    public function getEvents(\DateTime $begin, \DateTime $end, array $options = array());
+    public function getEvents(\DateTimeInterface $begin, \DateTimeInterface $end, array $options = array());
 }

--- a/src/Period/Day.php
+++ b/src/Period/Day.php
@@ -52,11 +52,11 @@ class Day extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('H:i:s') == '00:00:00';
     }

--- a/src/Period/Factory.php
+++ b/src/Period/Factory.php
@@ -43,7 +43,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createSecond(\DateTime $begin)
+    public function createSecond(\DateTimeInterface $begin)
     {
         return new $this->options['second_class']($begin, $this);
     }
@@ -51,7 +51,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createMinute(\DateTime $begin)
+    public function createMinute(\DateTimeInterface $begin)
     {
         return new $this->options['minute_class']($begin, $this);
     }
@@ -59,7 +59,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createHour(\DateTime $begin)
+    public function createHour(\DateTimeInterface $begin)
     {
         return new $this->options['hour_class']($begin, $this);
     }
@@ -67,7 +67,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createDay(\DateTime $begin)
+    public function createDay(\DateTimeInterface $begin)
     {
         return new $this->options['day_class']($begin, $this);
     }
@@ -75,7 +75,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createWeek(\DateTime $begin)
+    public function createWeek(\DateTimeInterface $begin)
     {
         return new $this->options['week_class']($begin, $this);
     }
@@ -83,7 +83,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createMonth(\DateTime $begin)
+    public function createMonth(\DateTimeInterface $begin)
     {
         return new $this->options['month_class']($begin, $this);
     }
@@ -91,7 +91,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createYear(\DateTime $begin)
+    public function createYear(\DateTimeInterface $begin)
     {
         return new $this->options['year_class']($begin, $this);
     }
@@ -99,7 +99,7 @@ class Factory implements FactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createRange(\DateTime $begin, \DateTime $end)
+    public function createRange(\DateTimeInterface $begin, \DateTimeInterface $end)
     {
         return new $this->options['range_class']($begin, $end, $this);
     }

--- a/src/Period/FactoryInterface.php
+++ b/src/Period/FactoryInterface.php
@@ -18,75 +18,75 @@ interface FactoryInterface
     /**
      * Create and return a Second.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createSecond(\DateTime $begin);
+    public function createSecond(\DateTimeInterface $begin);
 
     /**
      * Create and return a Minute.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createMinute(\DateTime $begin);
+    public function createMinute(\DateTimeInterface $begin);
 
     /**
      * Create and return an Hour.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createHour(\DateTime $begin);
+    public function createHour(\DateTimeInterface $begin);
 
     /**
      * Create and return a Day.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createDay(\DateTime $begin);
+    public function createDay(\DateTimeInterface $begin);
 
     /**
      * Create and return a Week.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createWeek(\DateTime $begin);
+    public function createWeek(\DateTimeInterface $begin);
 
     /**
      * Create and return a Month.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createMonth(\DateTime $begin);
+    public function createMonth(\DateTimeInterface $begin);
 
     /**
      * Create and return a Year.
      *
-     * @param \DateTime $begin
+     * @param \DateTimeInterface $begin
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createYear(\DateTime $begin);
+    public function createYear(\DateTimeInterface $begin);
 
     /**
      * Create and return a Range.
      *
-     * @param \DateTime $begin
-     * @param \DateTime $end
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
      *
      * @return \CalendR\Period\PeriodInterface
      */
-    public function createRange(\DateTime $begin, \DateTime $end);
+    public function createRange(\DateTimeInterface $begin, \DateTimeInterface $end);
 
     /**
      * @param int $firstWeekday
@@ -103,9 +103,9 @@ interface FactoryInterface
     /**
      * Find the first day of the given week.
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function findFirstDayOfWeek($dateTime);
 }

--- a/src/Period/Hour.php
+++ b/src/Period/Hour.php
@@ -26,11 +26,11 @@ class Hour extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('i:s') == '00:00';
     }

--- a/src/Period/Minute.php
+++ b/src/Period/Minute.php
@@ -25,11 +25,11 @@ class Minute extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('s') == '00';
     }

--- a/src/Period/Month.php
+++ b/src/Period/Month.php
@@ -43,7 +43,7 @@ class Month extends PeriodAbstract implements \Iterator
      * Returns the first day of the first week of month.
      * First day of week is configurable via {@link Factory:setOption()}.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getFirstDayOfFirstWeek()
     {
@@ -65,7 +65,7 @@ class Month extends PeriodAbstract implements \Iterator
      * Returns the last day of last week of month
      * First day of week is configurable via {@link Factory::setOption()}.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getLastDayOfLastWeek()
     {
@@ -139,11 +139,11 @@ class Month extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('d H:i:s') === '01 00:00:00';
     }

--- a/src/Period/PeriodAbstract.php
+++ b/src/Period/PeriodAbstract.php
@@ -21,12 +21,12 @@ use CalendR\Event\EventInterface;
 abstract class PeriodAbstract implements PeriodInterface
 {
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $begin;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $end;
 
@@ -36,12 +36,12 @@ abstract class PeriodAbstract implements PeriodInterface
     protected $factory;
 
     /**
-     * @param \DateTime        $begin
-     * @param FactoryInterface $factory
+     * @param \DateTimeInterface $begin
+     * @param FactoryInterface   $factory
      *
      * @throws \CalendR\Exception
      */
-    public function __construct(\DateTime $begin, FactoryInterface $factory)
+    public function __construct(\DateTimeInterface $begin, FactoryInterface $factory)
     {
         $this->factory = $factory;
         if (!static::isValid($begin)) {
@@ -56,11 +56,11 @@ abstract class PeriodAbstract implements PeriodInterface
     /**
      * Checks if the given period is contained in the current period.
      *
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      *
      * @return bool true if the period contains this date
      */
-    public function contains(\DateTime $date)
+    public function contains(\DateTimeInterface $date)
     {
         return $this->begin <= $date && $date < $this->end;
     }
@@ -171,7 +171,7 @@ abstract class PeriodAbstract implements PeriodInterface
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getBegin()
     {
@@ -179,7 +179,7 @@ abstract class PeriodAbstract implements PeriodInterface
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getEnd()
     {

--- a/src/Period/PeriodInterface.php
+++ b/src/Period/PeriodInterface.php
@@ -23,23 +23,23 @@ interface PeriodInterface
     /**
      * Checks if the given period is contained in the current period.
      *
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      *
      * @return bool true if the period contains this date
      */
-    public function contains(\DateTime $date);
+    public function contains(\DateTimeInterface $date);
 
     /**
      * Gets the DateTime of period begin.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getBegin();
 
     /**
      * Gets the DateTime of the period end.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getEnd();
 
@@ -115,9 +115,9 @@ interface PeriodInterface
     /**
      * Checks if $start is good for building the period.
      *
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      */
-    public static function isValid(\DateTime $start);
+    public static function isValid(\DateTimeInterface $start);
 
     /**
      * Returns a \DateInterval equivalent to the period.

--- a/src/Period/Range.php
+++ b/src/Period/Range.php
@@ -19,11 +19,11 @@ namespace CalendR\Period;
 class Range extends PeriodAbstract
 {
     /**
-     * @param \DateTime        $begin
-     * @param \DateTime        $end
-     * @param FactoryInterface $factory
+     * @param \DateTimeInterface $begin
+     * @param \DateTimeInterface $end
+     * @param FactoryInterface   $factory
      */
-    public function __construct(\DateTime $begin, \DateTime $end, $factory = null)
+    public function __construct(\DateTimeInterface $begin, \DateTimeInterface $end, $factory = null)
     {
         $this->factory = $factory;
         $this->begin   = clone $begin;
@@ -31,17 +31,17 @@ class Range extends PeriodAbstract
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return true;
     }
 
     /**
-     * @return Day
+     * @return Range
      */
     public function getNext()
     {
@@ -55,7 +55,7 @@ class Range extends PeriodAbstract
     }
 
     /**
-     * @return Day
+     * @return Range
      */
     public function getPrevious()
     {

--- a/src/Period/Second.php
+++ b/src/Period/Second.php
@@ -20,11 +20,11 @@ class Second extends PeriodAbstract
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('u') === '000000';
     }

--- a/src/Period/Week.php
+++ b/src/Period/Week.php
@@ -33,11 +33,11 @@ class Week extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         if ($start->format('H:i:s') !== '00:00:00') {
             return false;

--- a/src/Period/Year.php
+++ b/src/Period/Year.php
@@ -25,11 +25,11 @@ class Year extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * @param \DateTime $start
+     * @param \DateTimeInterface $start
      *
      * @return bool
      */
-    public static function isValid(\DateTime $start)
+    public static function isValid(\DateTimeInterface $start)
     {
         return $start->format('d-m H:i:s') === '01-01 00:00:00';
     }

--- a/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/EventProviderPassTest.php
+++ b/tests/Bridge/Symfony/Bundle/DependencyInjection/Compiler/EventProviderPassTest.php
@@ -25,7 +25,7 @@ class EventProviderPassTest extends TestCase
     public function testProcess()
     {
         $eventManagerDefinition = $this->getMockBuilder(Definition::class)->getMock();
-        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)->setMethods(['findTaggedServiceIds', 'getDefinition'])->getMock();
+        $containerBuilder = $this->getMockBuilder(ContainerBuilder::class)->onlyMethods(['findTaggedServiceIds', 'getDefinition'])->getMock();
         $containerBuilder->expects($this->once())->method('getDefinition')->with(Manager::class)->willReturn($eventManagerDefinition);
         $containerBuilder
             ->expects($this->once())
@@ -36,8 +36,10 @@ class EventProviderPassTest extends TestCase
                 'service2' => [['alias' => 'service2_alias']]
             ]);
 
-        $eventManagerDefinition->expects($this->at(0))->method('addMethodCall')->with('addProvider', ['service1', new Reference('service1')]);
-        $eventManagerDefinition->expects($this->at(1))->method('addMethodCall')->with('addProvider', ['service2_alias', new Reference('service2')]);
+        $eventManagerDefinition->expects($this->exactly(2))->method('addMethodCall')->withConsecutive(
+            ['addProvider', ['service1', new Reference('service1')]],
+            ['addProvider', ['service2_alias', new Reference('service2')]],
+        );
 
         $pass = new EventProviderPass;
         $pass->process($containerBuilder);

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -5,104 +5,117 @@ namespace CalendR\Test;
 use CalendR\Calendar;
 use CalendR\Period\Day;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use CalendR\Period\Year;
+use CalendR\Event\Manager;
+use CalendR\Period\FactoryInterface;
+use CalendR\Event\EventInterface;
+use CalendR\Period\PeriodInterface;
+use CalendR\Period\Second;
+use CalendR\Period\Minute;
+use CalendR\Period\Hour;
+use CalendR\Period\Week;
+use CalendR\Period\Month;
 
 class CalendarTest extends TestCase
 {
-    public function testGetYear()
+    use ProphecyTrait;
+
+    public function testGetYear(): void
     {
         $calendar = new Calendar;
 
         $year = $calendar->getYear(new \DateTime('2012-01'));
-        $this->assertInstanceOf('CalendR\\Period\\Year', $year);
+        $this->assertInstanceOf(Year::class, $year);
 
         $year = $calendar->getYear(2012);
-        $this->assertInstanceOf('CalendR\\Period\\Year', $year);
+        $this->assertInstanceOf(Year::class, $year);
     }
 
-    public function testGetMonth()
+    public function testGetMonth(): void
     {
         $calendar = new Calendar;
 
         $month = $calendar->getMonth(new \DateTime('2012-01-01'));
-        $this->assertInstanceOf('CalendR\\Period\\Month', $month);
+        $this->assertInstanceOf(Month::class, $month);
 
         $month = $calendar->getMonth(2012, 01);
-        $this->assertInstanceOf('CalendR\\Period\\Month', $month);
+        $this->assertInstanceOf(Month::class, $month);
     }
 
-    public function testGetWeek()
+    public function testGetWeek(): void
     {
         $calendar = new Calendar;
 
         $week = $calendar->getWeek(new \DateTime('2012-W01'));
-        $this->assertInstanceOf('CalendR\\Period\\Week', $week);
+        $this->assertInstanceOf(Week::class, $week);
 
         $week = $calendar->getWeek(2012, 1);
-        $this->assertInstanceOf('CalendR\\Period\\Week', $week);
+        $this->assertInstanceOf(Week::class, $week);
     }
 
-    public function testGetDay()
+    public function testGetDay(): void
     {
         $calendar = new Calendar;
 
         $day = $calendar->getDay(new \DateTime('2012-01-01'));
-        $this->assertInstanceOf('CalendR\\Period\\Day', $day);
+        $this->assertInstanceOf(Day::class, $day);
 
         $day = $calendar->getDay(2012, 1, 1);
-        $this->assertInstanceOf('CalendR\\Period\\Day', $day);
+        $this->assertInstanceOf(Day::class, $day);
     }
 
-    public function testGetHour()
+    public function testGetHour(): void
     {
         $calendar = new Calendar;
 
         $hour = $calendar->getHour(new \DateTime('2012-01-01 17:00'));
-        $this->assertInstanceOf('CalendR\\Period\\Hour', $hour);
+        $this->assertInstanceOf(Hour::class, $hour);
 
         $hour = $calendar->getHour(2012, 1, 1, 17);
-        $this->assertInstanceOf('CalendR\\Period\\Hour', $hour);
+        $this->assertInstanceOf(Hour::class, $hour);
     }
 
-    public function testGetMinute()
+    public function testGetMinute(): void
     {
         $calendar = new Calendar;
 
         $minute = $calendar->getMinute(new \DateTime('2012-01-01 17:23'));
-        $this->assertInstanceOf('CalendR\\Period\\Minute', $minute);
+        $this->assertInstanceOf(Minute::class, $minute);
 
         $minute = $calendar->getMinute(2012, 1, 1, 17, 23);
-        $this->assertInstanceOf('CalendR\\Period\\Minute', $minute);
+        $this->assertInstanceOf(Minute::class, $minute);
     }
 
-    public function testGetSecond()
+    public function testGetSecond(): void
     {
         $calendar = new Calendar;
 
         $second = $calendar->getSecond(new \DateTime('2012-01-01 17:23:49'));
-        $this->assertInstanceOf('CalendR\\Period\\Second', $second);
+        $this->assertInstanceOf(Second::class, $second);
 
         $second = $calendar->getSecond(2012, 1, 1, 17, 23, 49);
-        $this->assertInstanceOf('CalendR\\Period\\Second', $second);
+        $this->assertInstanceOf(Second::class, $second);
     }
 
-    public function testGetEvents()
+    public function testGetEvents(): void
     {
-        $em       = $this->getMockBuilder('CalendR\Event\Manager')->getMock();
-        $period   = $this->getMockBuilder('CalendR\Period\PeriodInterface')->getMock();
-        $events   = array($this->getMockBuilder('CalendR\Event\EventInterface')->getMock());
+        $em       = $this->getMockBuilder(Manager::class)->getMock();
+        $period   = $this->getMockBuilder(PeriodInterface::class)->getMock();
+        $events   = array($this->getMockBuilder(EventInterface::class)->getMock());
         $calendar = new Calendar;
         $calendar->setEventManager($em);
-        $em->expects($this->once())->method('find')->with($period, array())->will($this->returnValue($events));
+        $em->expects($this->once())->method('find')->with($period, array())->willReturn($events);
 
         $this->assertSame($events, $calendar->getEvents($period, array()));
     }
 
-    public function testGetFirstWeekday()
+    public function testGetFirstWeekday(): void
     {
         $calendar = new Calendar;
-        $factory  = $this->getMockBuilder('CalendR\Period\FactoryInterface')->getMock();
+        $factory  = $this->getMockBuilder(FactoryInterface::class)->getMock();
         $calendar->setFactory($factory);
-        $factory->expects($this->once())->method('getFirstWeekday')->will($this->returnValue(Day::SUNDAY));
+        $factory->expects($this->once())->method('getFirstWeekday')->willReturn(Day::SUNDAY);
 
         $this->assertSame(Day::SUNDAY, $calendar->getFirstWeekday());
     }
@@ -110,7 +123,7 @@ class CalendarTest extends TestCase
     /**
      * @dataProvider weekAndWeekdayProvider
      */
-    public function testGetWeekWithWeekdayConfiguration($year, $week, $weekday, $day)
+    public function testGetWeekWithWeekdayConfiguration($year, $week, $weekday, $day): void
     {
         $calendar = new Calendar;
         $calendar->getFactory()->setFirstWeekday($weekday);
@@ -120,13 +133,13 @@ class CalendarTest extends TestCase
         $this->assertSame($day, $week->format('Y-m-d'));
     }
 
-    public function testGetEventManager()
+    public function testGetEventManager(): void
     {
         $calendar = new Calendar;
-        $this->assertInstanceOf('CalendR\Event\Manager', $calendar->getEventManager());
+        $this->assertInstanceOf(Manager::class, $calendar->getEventManager());
     }
 
-    public static function weekAndWeekdayProvider()
+    public static function weekAndWeekdayProvider(): array
     {
         return array(
             array(2013, 1, Day::MONDAY, '2012-12-31'),

--- a/tests/Event/ManagerTest.php
+++ b/tests/Event/ManagerTest.php
@@ -9,6 +9,7 @@ use CalendR\Period\FactoryInterface;
 use CalendR\Period\Month;
 use CalendR\Event\Provider\Basic;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Test class for Manager.
@@ -16,6 +17,8 @@ use PHPUnit\Framework\TestCase;
  */
 class ManagerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var Manager
      */

--- a/tests/Period/DayTest.php
+++ b/tests/Period/DayTest.php
@@ -8,9 +8,12 @@ use CalendR\Period\FactoryInterface;
 use CalendR\Period\PeriodInterface;
 use CalendR\Period\Year;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DayTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerConstructInvalid()
     {
         return array(

--- a/tests/Period/HourTest.php
+++ b/tests/Period/HourTest.php
@@ -11,9 +11,12 @@ use CalendR\Period\Day;
 use CalendR\Period\PeriodInterface;
 use CalendR\Period\Year;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class HourTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerConstructInvalid()
     {
         return array(

--- a/tests/Period/MinuteTest.php
+++ b/tests/Period/MinuteTest.php
@@ -11,9 +11,11 @@ use CalendR\Period\Day;
 use CalendR\Period\PeriodInterface;
 use CalendR\Period\Year;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MinuteTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * Data Provider: Invalid Constructor

--- a/tests/Period/MonthTest.php
+++ b/tests/Period/MonthTest.php
@@ -7,9 +7,12 @@ use CalendR\Period\Factory;
 use CalendR\Period\FactoryInterface;
 use CalendR\Period\Month;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MonthTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerConstructInvalid()
     {
         return array(

--- a/tests/Period/RangeTest.php
+++ b/tests/Period/RangeTest.php
@@ -5,9 +5,12 @@ namespace CalendR\Test\Period;
 use CalendR\Period\FactoryInterface;
 use CalendR\Period\Range;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class RangeTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerContains()
     {
         return array(

--- a/tests/Period/SecondTest.php
+++ b/tests/Period/SecondTest.php
@@ -10,9 +10,11 @@ use CalendR\Period\Day;
 use CalendR\Period\PeriodInterface;
 use CalendR\Period\Year;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class SecondTest extends TestCase
 {
+    use ProphecyTrait;
 
     /**
      * Data Provider: Valid Constructor

--- a/tests/Period/WeekTest.php
+++ b/tests/Period/WeekTest.php
@@ -6,9 +6,12 @@ use CalendR\Period\Factory;
 use CalendR\Period\FactoryInterface;
 use CalendR\Period\Week;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class WeekTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerConstructValid()
     {
         return array(

--- a/tests/Period/YearTest.php
+++ b/tests/Period/YearTest.php
@@ -8,9 +8,12 @@ use CalendR\Period\Factory;
 use CalendR\Period\FactoryInterface;
 use CalendR\Period\Year;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class YearTest extends TestCase
 {
+    use ProphecyTrait;
+
     public static function providerConstructInvalid()
     {
         return array(


### PR DESCRIPTION
Permit usage of other classes that represent date and time, like \DateTimeImmutable or Carbon