### PR TITLE
Silence PHP 8.1 deprecation notices for return types

### DIFF
--- a/src/Event/Collection/Basic.php
+++ b/src/Event/Collection/Basic.php
@@ -107,6 +107,7 @@ class Basic implements CollectionInterface
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->events);

--- a/src/Event/Collection/Indexed.php
+++ b/src/Event/Collection/Indexed.php
@@ -170,6 +170,7 @@ class Indexed implements CollectionInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->count;

--- a/src/Event/Provider/Basic.php
+++ b/src/Event/Provider/Basic.php
@@ -71,6 +71,7 @@ class Basic implements ProviderInterface, \IteratorAggregate, \Countable
      *
      * @return \Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->events);
@@ -81,6 +82,7 @@ class Basic implements ProviderInterface, \IteratorAggregate, \Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->events);

--- a/src/Period/Day.php
+++ b/src/Period/Day.php
@@ -76,6 +76,7 @@ class Day extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -84,6 +85,7 @@ class Day extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (null === $this->current) {
@@ -99,6 +101,7 @@ class Day extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return (int) $this->current->getBegin()->format('G');
@@ -107,6 +110,7 @@ class Day extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current;
@@ -115,6 +119,7 @@ class Day extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;

--- a/src/Period/Hour.php
+++ b/src/Period/Hour.php
@@ -38,6 +38,7 @@ class Hour extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -46,6 +47,7 @@ class Hour extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (null === $this->current) {
@@ -61,6 +63,7 @@ class Hour extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return (int) $this->current->getBegin()->format('G');
@@ -69,6 +72,7 @@ class Hour extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current;
@@ -77,6 +81,7 @@ class Hour extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;

--- a/src/Period/Minute.php
+++ b/src/Period/Minute.php
@@ -37,6 +37,7 @@ class Minute extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -45,6 +46,7 @@ class Minute extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (null === $this->current) {
@@ -60,6 +62,7 @@ class Minute extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return (int) $this->current->getBegin()->format('i');
@@ -68,6 +71,7 @@ class Minute extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current;
@@ -76,6 +80,7 @@ class Minute extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;

--- a/src/Period/Month.php
+++ b/src/Period/Month.php
@@ -82,6 +82,7 @@ class Month extends PeriodAbstract implements \Iterator
     /**
      * @return Week
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -90,6 +91,7 @@ class Month extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (!$this->valid()) {
@@ -106,6 +108,7 @@ class Month extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->current->getBegin()->format('W');
@@ -114,6 +117,7 @@ class Month extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current();
@@ -122,6 +126,7 @@ class Month extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;

--- a/src/Period/Week.php
+++ b/src/Period/Week.php
@@ -49,6 +49,7 @@ class Week extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -57,6 +58,7 @@ class Week extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (!$this->valid()) {
@@ -72,6 +74,7 @@ class Week extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->current->getBegin()->format('d-m-Y');
@@ -80,6 +83,7 @@ class Week extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current;
@@ -88,6 +92,7 @@ class Week extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;

--- a/src/Period/Year.php
+++ b/src/Period/Year.php
@@ -37,6 +37,7 @@ class Year extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -45,6 +46,7 @@ class Year extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if (null === $this->current) {
@@ -60,6 +62,7 @@ class Year extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->current->getBegin()->format('m');
@@ -68,6 +71,7 @@ class Year extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->current;
@@ -76,6 +80,7 @@ class Year extends PeriodAbstract implements \Iterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->current = null;


### PR DESCRIPTION
This PR adds attributes to silence PHP 8.1 deprecation notices for missing return types.

For some background, see https://stackoverflow.com/questions/71133749/reference-return-type-of-should-either-be-compatible-with-or-the-re.

This allows to use the library (or run the unit tests) with PHP 8.1 without notices. 

The "Pimple" dependency is still an issue, but is only a dev-requirement, so no immediate need to worry about that.