### PR TITLE
Fix PeriodAbstract constructor when DateTimeImmutable instances are passed

### DIFF
--- a/src/Period/PeriodAbstract.php
+++ b/src/Period/PeriodAbstract.php
@@ -48,8 +48,8 @@ abstract class PeriodAbstract implements PeriodInterface
             throw $this->createInvalidException();
         }
 
-        $this->begin = clone $begin;
-        $this->end   = clone $begin;
+        $this->begin = \DateTime::createFromInterface($begin);
+        $this->end   = \DateTime::createFromInterface($begin);
         $this->end->add($this->getDateInterval());
     }
 


### PR DESCRIPTION
When `DateTimeImmutable` instances are used, the `$this->end->add(...)` call will not modify `$this->end`. It does not matter that a clone is used.